### PR TITLE
[2.3] ability to pass json_encode options in BaseObject::toJson

### DIFF
--- a/src/Objects/BaseObject.php
+++ b/src/Objects/BaseObject.php
@@ -87,11 +87,12 @@ abstract class BaseObject implements JsonSerializable
     }
 
     /**
+     * @param int $options
      * @return string
      */
-    public function toJson(): string
+    public function toJson($options = 0): string
     {
-        return json_encode($this->toArray());
+        return json_encode($this->toArray(), $options);
     }
 
     /**


### PR DESCRIPTION
For example to pretty print json