### PR TITLE
MediaType application/x-www-form-urlencoded

### DIFF
--- a/src/Objects/MediaType.php
+++ b/src/Objects/MediaType.php
@@ -120,6 +120,10 @@ class MediaType extends BaseObject
             ->mediaType(static::MEDIA_TYPE_TEXT_XML);
     }
 
+    /**
+     * @param string|null $objectId
+     * @return \GoldSpecDigital\ObjectOrientedOAS\Objects\MediaType
+     */
     public static function formUrlEncoded(string $objectId = null): self
     {
         return static::create($objectId)

--- a/src/Objects/MediaType.php
+++ b/src/Objects/MediaType.php
@@ -23,6 +23,7 @@ class MediaType extends BaseObject
     const MEDIA_TYPE_TEXT_CALENDAR = 'text/calendar';
     const MEDIA_TYPE_TEXT_PLAIN = 'text/plain';
     const MEDIA_TYPE_TEXT_XML = 'text/xml';
+    const MEDIA_TYPE_APPLICATION_X_WWW_FORM_URLENCODED = 'application/x-www-form-urlencoded';
 
     /**
      * @var string|null
@@ -117,6 +118,12 @@ class MediaType extends BaseObject
     {
         return static::create($objectId)
             ->mediaType(static::MEDIA_TYPE_TEXT_XML);
+    }
+
+    public static function formUrlEncoded(string $objectId = null): self
+    {
+        return static::create($objectId)
+            ->mediaType(static::MEDIA_TYPE_APPLICATION_X_WWW_FORM_URLENCODED);
     }
 
     /**


### PR DESCRIPTION
Add MediaType application/x-www-form-urlencoded.

According to OpenAPI specification (https://github.com/OAI/OpenAPI-Specification/blob/master/versions/3.0.2.md#mediaTypeObject) we can use `application/x-www-form-urlencoded` for RequestBody objects.