### PR TITLE
Add ReturnTypeWillChange attributes and add workflows for PHP8.0 and PHP8.1

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -13,7 +13,7 @@ jobs:
     strategy:
       fail-fast: true
       matrix:
-        php: [7.1, 7.2, 7.3, 7.4]
+        php: [7.1, 7.2, 7.3, 7.4, 8.0, 8.1]
         stability: [prefer-lowest, prefer-stable]
 
     name: PHP ${{ matrix.php }} - ${{ matrix.stability }}

--- a/composer.json
+++ b/composer.json
@@ -30,7 +30,7 @@
     "ext-json": "*"
   },
   "require-dev": {
-    "phpunit/phpunit": "^7.3",
+    "phpunit/phpunit": ">=7.3",
     "friendsofphp/php-cs-fixer": "^2.17",
     "justinrainbow/json-schema": "^5.2"
   },

--- a/src/Utilities/Extensions.php
+++ b/src/Utilities/Extensions.php
@@ -26,6 +26,7 @@ class Extensions implements ArrayAccess
      * @param mixed $offset
      * @return bool
      */
+    #[\ReturnTypeWillChange]
     public function offsetExists($offset)
     {
         return isset($this->items[$this->normalizeOffset($offset)]);
@@ -39,6 +40,7 @@ class Extensions implements ArrayAccess
      * @throws \GoldSpecDigital\ObjectOrientedOAS\Exceptions\ExtensionDoesNotExistException
      * @return mixed can return all value types
      */
+    #[\ReturnTypeWillChange]
     public function offsetGet($offset)
     {
         if (!$this->offsetExists($offset)) {
@@ -55,6 +57,7 @@ class Extensions implements ArrayAccess
      * @param mixed $offset
      * @param mixed $value
      */
+    #[\ReturnTypeWillChange]
     public function offsetSet($offset, $value)
     {
         if ($value === static::X_EMPTY_VALUE) {
@@ -72,6 +75,7 @@ class Extensions implements ArrayAccess
      * @link https://php.net/manual/en/arrayaccess.offsetunset.php
      * @param mixed $offset
      */
+    #[\ReturnTypeWillChange]
     public function offsetUnset($offset)
     {
         if (!$this->offsetExists($offset)) {

--- a/tests/Objects/ExtensionsTest.php
+++ b/tests/Objects/ExtensionsTest.php
@@ -2,6 +2,7 @@
 
 namespace GoldSpecDigital\ObjectOrientedOAS\Tests\Objects;
 
+use GoldSpecDigital\ObjectOrientedOAS\Exceptions\PropertyDoesNotExistException;
 use GoldSpecDigital\ObjectOrientedOAS\Objects\Components;
 use GoldSpecDigital\ObjectOrientedOAS\Objects\Operation;
 use GoldSpecDigital\ObjectOrientedOAS\Objects\PathItem;
@@ -69,7 +70,6 @@ class ExtensionsTest extends TestCase
 
     /**
      * @test
-     * @expectedException \GoldSpecDigital\ObjectOrientedOAS\Exceptions\PropertyDoesNotExistException
      * @dataProvider schemasDataProvider
      * @param string|\GoldSpecDigital\ObjectOrientedOAS\Objects\Schema $schema
      */
@@ -77,6 +77,8 @@ class ExtensionsTest extends TestCase
     {
         $object = $schema::create()->x('foo', 'bar');
 
+        $this->expectException(PropertyDoesNotExistException::class);
+        $this->expectExceptionMessage('[x-key] is not a valid property');
         $this->assertEquals('bar', $object->{'x-key'});
     }
 


### PR DESCRIPTION
As discussed in #53 , instead of adding the missing return types this PR adds the ReturnTypeWillChange attribute. It also adds PHP8.0 and PHP8.1 to the test matrix.