### PR TITLE
fix: implicitly nullable parameter declarations deprecated

### DIFF
--- a/src/Exceptions/ValidationException.php
+++ b/src/Exceptions/ValidationException.php
@@ -11,7 +11,7 @@ class ValidationException extends Exception
 {
     protected $errors;
 
-    public function __construct(array $errors, $message = '', $code = 0, Throwable $previous = null)
+    public function __construct(array $errors, $message = '', $code = 0, ?Throwable $previous = null)
     {
         parent::__construct($message, $code, $previous);
 

--- a/src/Objects/BaseObject.php
+++ b/src/Objects/BaseObject.php
@@ -35,7 +35,7 @@ abstract class BaseObject implements JsonSerializable
      *
      * @param string|null $objectId
      */
-    public function __construct(string $objectId = null)
+    public function __construct(?string $objectId = null)
     {
         $this->objectId = $objectId;
         $this->extensions = new Extensions();
@@ -45,7 +45,7 @@ abstract class BaseObject implements JsonSerializable
      * @param string|null $objectId
      * @return static
      */
-    public static function create(string $objectId = null): self
+    public static function create(?string $objectId = null): self
     {
         return new static($objectId);
     }
@@ -55,7 +55,7 @@ abstract class BaseObject implements JsonSerializable
      * @param string|null $objectId
      * @return static
      */
-    public static function ref(string $ref, string $objectId = null): self
+    public static function ref(string $ref, ?string $objectId = null): self
     {
         $instance = new static($objectId);
 

--- a/src/Objects/MediaType.php
+++ b/src/Objects/MediaType.php
@@ -54,7 +54,7 @@ class MediaType extends BaseObject
      * @param string|null $objectId
      * @return static
      */
-    public static function json(string $objectId = null): self
+    public static function json(?string $objectId = null): self
     {
         return static::create($objectId)
             ->mediaType(static::MEDIA_TYPE_APPLICATION_JSON);
@@ -64,7 +64,7 @@ class MediaType extends BaseObject
      * @param string|null $objectId
      * @return static
      */
-    public static function pdf(string $objectId = null): self
+    public static function pdf(?string $objectId = null): self
     {
         return static::create($objectId)
             ->mediaType(static::MEDIA_TYPE_APPLICATION_PDF);
@@ -74,7 +74,7 @@ class MediaType extends BaseObject
      * @param string|null $objectId
      * @return static
      */
-    public static function jpeg(string $objectId = null): self
+    public static function jpeg(?string $objectId = null): self
     {
         return static::create($objectId)
             ->mediaType(static::MEDIA_TYPE_IMAGE_JPEG);
@@ -84,7 +84,7 @@ class MediaType extends BaseObject
      * @param string|null $objectId
      * @return static
      */
-    public static function png(string $objectId = null): self
+    public static function png(?string $objectId = null): self
     {
         return static::create($objectId)
             ->mediaType(static::MEDIA_TYPE_IMAGE_PNG);
@@ -94,7 +94,7 @@ class MediaType extends BaseObject
      * @param string|null $objectId
      * @return static
      */
-    public static function calendar(string $objectId = null): self
+    public static function calendar(?string $objectId = null): self
     {
         return static::create($objectId)
             ->mediaType(static::MEDIA_TYPE_TEXT_CALENDAR);
@@ -104,7 +104,7 @@ class MediaType extends BaseObject
      * @param string|null $objectId
      * @return static
      */
-    public static function plainText(string $objectId = null): self
+    public static function plainText(?string $objectId = null): self
     {
         return static::create($objectId)
             ->mediaType(static::MEDIA_TYPE_TEXT_PLAIN);
@@ -114,7 +114,7 @@ class MediaType extends BaseObject
      * @param string|null $objectId
      * @return static
      */
-    public static function xml(string $objectId = null): self
+    public static function xml(?string $objectId = null): self
     {
         return static::create($objectId)
             ->mediaType(static::MEDIA_TYPE_TEXT_XML);
@@ -124,7 +124,7 @@ class MediaType extends BaseObject
      * @param string|null $objectId
      * @return static
      */
-    public static function formUrlEncoded(string $objectId = null): self
+    public static function formUrlEncoded(?string $objectId = null): self
     {
         return static::create($objectId)
             ->mediaType(static::MEDIA_TYPE_APPLICATION_X_WWW_FORM_URLENCODED);

--- a/src/Objects/Operation.php
+++ b/src/Objects/Operation.php
@@ -107,7 +107,7 @@ class Operation extends BaseObject
      * @param string|null $objectId
      * @return static
      */
-    public static function get(string $objectId = null): self
+    public static function get(?string $objectId = null): self
     {
         return static::create($objectId)->action(static::ACTION_GET);
     }
@@ -116,7 +116,7 @@ class Operation extends BaseObject
      * @param string|null $objectId
      * @return static
      */
-    public static function put(string $objectId = null): self
+    public static function put(?string $objectId = null): self
     {
         return static::create($objectId)->action(static::ACTION_PUT);
     }
@@ -125,7 +125,7 @@ class Operation extends BaseObject
      * @param string|null $objectId
      * @return static
      */
-    public static function post(string $objectId = null): self
+    public static function post(?string $objectId = null): self
     {
         return static::create($objectId)->action(static::ACTION_POST);
     }
@@ -134,7 +134,7 @@ class Operation extends BaseObject
      * @param string|null $objectId
      * @return static
      */
-    public static function delete(string $objectId = null): self
+    public static function delete(?string $objectId = null): self
     {
         return static::create($objectId)->action(static::ACTION_DELETE);
     }
@@ -143,7 +143,7 @@ class Operation extends BaseObject
      * @param string|null $objectId
      * @return static
      */
-    public static function head(string $objectId = null): self
+    public static function head(?string $objectId = null): self
     {
         return static::create($objectId)->action(static::ACTION_HEAD);
     }
@@ -152,7 +152,7 @@ class Operation extends BaseObject
      * @param string|null $objectId
      * @return static
      */
-    public static function patch(string $objectId = null): self
+    public static function patch(?string $objectId = null): self
     {
         return static::create($objectId)->action(static::ACTION_PATCH);
     }
@@ -161,7 +161,7 @@ class Operation extends BaseObject
      * @param string|null $objectId
      * @return static
      */
-    public static function trace(string $objectId = null): self
+    public static function trace(?string $objectId = null): self
     {
         return static::create($objectId)->action(static::ACTION_TRACE);
     }

--- a/src/Objects/Parameter.php
+++ b/src/Objects/Parameter.php
@@ -106,7 +106,7 @@ class Parameter extends BaseObject
      * @param string|null $objectId
      * @return static
      */
-    public static function query(string $objectId = null): self
+    public static function query(?string $objectId = null): self
     {
         return static::create($objectId)->in(static::IN_QUERY);
     }
@@ -115,7 +115,7 @@ class Parameter extends BaseObject
      * @param string|null $objectId
      * @return static
      */
-    public static function header(string $objectId = null): self
+    public static function header(?string $objectId = null): self
     {
         return static::create($objectId)->in(static::IN_HEADER);
     }
@@ -124,7 +124,7 @@ class Parameter extends BaseObject
      * @param string|null $objectId
      * @return static
      */
-    public static function path(string $objectId = null): self
+    public static function path(?string $objectId = null): self
     {
         return static::create($objectId)->in(static::IN_PATH);
     }
@@ -133,7 +133,7 @@ class Parameter extends BaseObject
      * @param string|null $objectId
      * @return static
      */
-    public static function cookie(string $objectId = null): self
+    public static function cookie(?string $objectId = null): self
     {
         return static::create($objectId)->in(static::IN_COOKIE);
     }

--- a/src/Objects/Response.php
+++ b/src/Objects/Response.php
@@ -44,7 +44,7 @@ class Response extends BaseObject
      * @param string|null $objectId
      * @return static
      */
-    public static function ok(string $objectId = null): self
+    public static function ok(?string $objectId = null): self
     {
         return static::create($objectId)
             ->statusCode(200)
@@ -55,7 +55,7 @@ class Response extends BaseObject
      * @param string|null $objectId
      * @return static
      */
-    public static function created(string $objectId = null): self
+    public static function created(?string $objectId = null): self
     {
         return static::create($objectId)
             ->statusCode(201)
@@ -66,7 +66,7 @@ class Response extends BaseObject
      * @param string|null $objectId
      * @return static
      */
-    public static function movedPermanently(string $objectId = null): self
+    public static function movedPermanently(?string $objectId = null): self
     {
         return static::create($objectId)
             ->statusCode(301)
@@ -77,7 +77,7 @@ class Response extends BaseObject
      * @param string|null $objectId
      * @return static
      */
-    public static function movedTemporarily(string $objectId = null): self
+    public static function movedTemporarily(?string $objectId = null): self
     {
         return static::create($objectId)
             ->statusCode(302)
@@ -88,7 +88,7 @@ class Response extends BaseObject
      * @param string|null $objectId
      * @return static
      */
-    public static function badRequest(string $objectId = null): self
+    public static function badRequest(?string $objectId = null): self
     {
         return static::create($objectId)
             ->statusCode(400)
@@ -99,7 +99,7 @@ class Response extends BaseObject
      * @param string|null $objectId
      * @return static
      */
-    public static function unauthorized(string $objectId = null): self
+    public static function unauthorized(?string $objectId = null): self
     {
         return static::create($objectId)
             ->statusCode(401)
@@ -110,7 +110,7 @@ class Response extends BaseObject
      * @param string|null $objectId
      * @return static
      */
-    public static function forbidden(string $objectId = null): self
+    public static function forbidden(?string $objectId = null): self
     {
         return static::create($objectId)
             ->statusCode(403)
@@ -121,7 +121,7 @@ class Response extends BaseObject
      * @param string|null $objectId
      * @return static
      */
-    public static function notFound(string $objectId = null): self
+    public static function notFound(?string $objectId = null): self
     {
         return static::create($objectId)
             ->statusCode(404)
@@ -132,7 +132,7 @@ class Response extends BaseObject
      * @param string|null $objectId
      * @return static
      */
-    public static function unprocessableEntity(string $objectId = null): self
+    public static function unprocessableEntity(?string $objectId = null): self
     {
         return static::create($objectId)
             ->statusCode(422)
@@ -143,7 +143,7 @@ class Response extends BaseObject
      * @param string|null $objectId
      * @return static
      */
-    public static function tooManyRequests(string $objectId = null): self
+    public static function tooManyRequests(?string $objectId = null): self
     {
         return static::create($objectId)
             ->statusCode(429)
@@ -154,7 +154,7 @@ class Response extends BaseObject
      * @param string|null $objectId
      * @return static
      */
-    public static function internalServerError(string $objectId = null): self
+    public static function internalServerError(?string $objectId = null): self
     {
         return static::create($objectId)
             ->statusCode(500)

--- a/src/Objects/Schema.php
+++ b/src/Objects/Schema.php
@@ -220,7 +220,7 @@ class Schema extends BaseObject implements SchemaContract
      * @param string|null $objectId
      * @return static
      */
-    public static function array(string $objectId = null): self
+    public static function array(?string $objectId = null): self
     {
         return static::create($objectId)->type(static::TYPE_ARRAY);
     }
@@ -229,7 +229,7 @@ class Schema extends BaseObject implements SchemaContract
      * @param string|null $objectId
      * @return static
      */
-    public static function boolean(string $objectId = null): self
+    public static function boolean(?string $objectId = null): self
     {
         return static::create($objectId)->type(static::TYPE_BOOLEAN);
     }
@@ -238,7 +238,7 @@ class Schema extends BaseObject implements SchemaContract
      * @param string|null $objectId
      * @return static
      */
-    public static function integer(string $objectId = null): self
+    public static function integer(?string $objectId = null): self
     {
         return static::create($objectId)->type(static::TYPE_INTEGER);
     }
@@ -247,7 +247,7 @@ class Schema extends BaseObject implements SchemaContract
      * @param string|null $objectId
      * @return static
      */
-    public static function number(string $objectId = null): self
+    public static function number(?string $objectId = null): self
     {
         return static::create($objectId)->type(static::TYPE_NUMBER);
     }
@@ -256,7 +256,7 @@ class Schema extends BaseObject implements SchemaContract
      * @param string|null $objectId
      * @return static
      */
-    public static function object(string $objectId = null): self
+    public static function object(?string $objectId = null): self
     {
         return static::create($objectId)->type(static::TYPE_OBJECT);
     }
@@ -265,7 +265,7 @@ class Schema extends BaseObject implements SchemaContract
      * @param string|null $objectId
      * @return static
      */
-    public static function string(string $objectId = null): self
+    public static function string(?string $objectId = null): self
     {
         return static::create($objectId)->type(static::TYPE_STRING);
     }

--- a/src/Objects/SecurityScheme.php
+++ b/src/Objects/SecurityScheme.php
@@ -71,7 +71,7 @@ class SecurityScheme extends BaseObject
      * @param string|null $objectId
      * @return static
      */
-    public static function oauth2(string $objectId = null): self
+    public static function oauth2(?string $objectId = null): self
     {
         return static::create($objectId)->type(static::TYPE_OAUTH2);
     }


### PR DESCRIPTION
Fixes a deprecation introduced in PHP 8.4.

> Implicitly marking parameter $some as nullable is deprecated, the explicit nullable type must be used instead